### PR TITLE
Update README with respect to the changed revision number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 ## Installation
 
-`typings install github:meteor-typings/react-meteor-data#0a089cf686de6af92170a72a18735351e480fcd9 --global`
+`typings install github:meteor-typings/react-meteor-data#955e4521623d6574dde8e0ed1b29967ec13f2c9d --global`


### PR DESCRIPTION
If you follow README instructions now, you end up with the initial version of the typings, without the changes to the method param types. I simply updated the README file to point the latest revision.