### PR TITLE
Removed restriction on output props type so it does not have to take …

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -10,7 +10,7 @@ declare module 'meteor/react-meteor-data' {
 
   type ComponentConstructor<P> = React.ComponentClass<P> | React.StatelessComponent<P>
 
-  export function createContainer<InP, D, OutP extends (InP & D)>(
+  export function createContainer<InP, D, OutP)>(
     options: (props: InP) => D | {getMeteorData: (props: InP) => D, pure?: boolean},
     reactComponent: ComponentConstructor<OutP>)
     : ComponentConstructor<InP>;


### PR DESCRIPTION
…all container props

In the current type definition, you have to pass all input props that the container is taking to the component that the container is managing the interaction with the meteor collections.  In this change, I'm allowing the container to selectively pass props.  This allows existing component libraries (Material-UI, react-bootstrap) to plug in without needing to wrap the components.

I'm using this change locally in my typings directory.